### PR TITLE
Brett/feature/populate friends

### DIFF
--- a/cypress/e2e/modal.cy.js
+++ b/cypress/e2e/modal.cy.js
@@ -14,31 +14,31 @@ describe('Modal', () => {
   })
 
   it('should show the game name in header', () => {
-    cy.get('h1').contains('Dominion')
+    cy.get('h1').contains('Ticket to Ride')
   })
 
   it('should show the game\'s inception date', () => {
-    cy.get('p').first().contains('2008')
+    cy.get('p').first().contains('2004')
   })
 
   it('should show how many users can play the game', () => {
-    cy.get('p').eq(1).contains('Players: 2 to 4')
+    cy.get('p').eq(1).contains('Players: 2 to 5')
   })
 
   it('should show the average playtime', () => {
-    cy.get('p').eq(2).contains('Average Playtime: 30 minutes')
+    cy.get('p').eq(2).contains('Average Playtime: 67.5 minutes')
   })
 
   it('should show the minimum allowable playing age', () => {
-    cy.get('p').eq(3).contains('13+')
+    cy.get('p').eq(3).contains('8+')
   })
 
   it('should have a description of the game', () => {
-    cy.get('p').eq(4).contains('You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens.')
+    cy.get('p').eq(4).contains('Ticket to Ride is a cross-country train adventure game. Players collect train cards that enable them to claim railway routes connecting cities throughout North America. The longer the routes, the more points they earn.')
   })
 
   it('should be able to see additional info from the game\'s website', () => {
-    cy.get('a').first().should('have.attr', 'href', "https://www.boardgameatlas.com/game/VO7TAxQ5Qn/dominion")
+    cy.get('a').first().should('have.attr', 'href', "https://www.boardgameatlas.com/game/AuBvbISHR6/ticket-to-ride")
   })
 
   it('should be able to exit modal', () => {

--- a/cypress/e2e/user_dashboad.cy.js
+++ b/cypress/e2e/user_dashboad.cy.js
@@ -26,27 +26,23 @@ describe('User Dashboard', () => {
   it('should show the user\'s list of friends', () => {
     cy.get('.friends-section').contains('My Friends')
     cy.get('.friends-list').should('be.visible')
-    cy.get('.friend').first().contains('Larry')
-    cy.get('.friend').eq(1).contains('Terry')
-    cy.get('.friend').eq(2).contains('Jerry')
-    cy.get('.friend').last().contains('Harry')
+    cy.get('.friend').first().contains('Pickafloof')
+    cy.get('.friend').eq(1).contains('mikedao')
+    cy.get('.friend').eq(2).contains('abdulredd')
+    //Will need to test all or stub data
   })
 
   it('should have a persistent Navbar', () => {
   })
 
   it('should show the user\'s games', () => {
-    cy.contains('Dominion')
-    cy.contains('Carcassonne')
-    cy.contains('Scythe')
+    cy.contains('Ticket to Ride')
+    cy.contains('Rummikub')
     cy.get('.game-collection')
       .find('.single-game-img')
-      .eq(0).should('have.attr', 'src', "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1559254200326-6135RVKbZZL.jpg")
+      .eq(0).should('have.attr', 'src', "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1629324738308.jpg")
     cy.get('.game-collection')
       .find('.single-game-img')
-      .eq(1).should('have.attr', 'src', "https://cdn11.bigcommerce.com/s-wue8xznink/images/stencil/1280x1280/products/357/17642/pic6544250_1__09565.1658423124.png?c=2")
-      cy.get('.game-collection')
-      .find('.single-game-img')
-      .eq(2).should('have.attr', 'src', "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922")
+      .eq(1).should('have.attr', 'src', "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1559254849801-61DrzE6DaPL.jpg")
   })
 })

--- a/src/GraphQL/mutations.js
+++ b/src/GraphQL/mutations.js
@@ -1,0 +1,21 @@
+import { gql } from "@apollo/client"
+
+export const CREATE_USER = (username) => gql`
+  mutation {
+    createUser(input: {username: ${username}}) {
+      user {
+        id
+        username
+      }
+    }
+  }
+`
+
+export const UPDATE_GAME = () => gql`
+    mutation {
+      users {
+          id
+          username
+      }  
+    }
+  `

--- a/src/GraphQL/queries.js
+++ b/src/GraphQL/queries.js
@@ -19,14 +19,32 @@ export const GET_USER = (userName) => gql`
             minAge
             description
             thumbUrl
-            imageUrl 
+            imageUrl
+            status
+            borrowerId
         }
     }
   }`
 
+export const GET_GAME_DETAIL = (id) => gql`
+    query {
+
+    }
+  `
+
+export const GET_SEARCHED_GAMES = (name) => gql`
+    query {
+      games(name: "${name}") {
+        board_game_atlas_id
+        name
+        thumb_url
+        image_url
+      }
+    }
+  `
 
 
-  export const GET_ALL_USERS = gql`
+export const GET_ALL_USERS = gql`
     query {
       users {
           id

--- a/src/GraphQL/queries.js
+++ b/src/GraphQL/queries.js
@@ -1,30 +1,95 @@
 import { gql } from "@apollo/client"
 
+//QUERIES
+//Search Games
+//Get Single User
+//Get Single Game
+//Get All Users (Friends)
 
 export const GET_USER = (userName) => gql`
    query {
     user(username: "${userName}") {
-        id
-        username
-        games {
-            id
-            boardGameAtlasId
-            url
-            name
-            yearPublished
-            minPlayers
-            maxPlayers
-            minPlaytime
-            maxPlaytime
-            minAge
-            description
-            thumbUrl
-            imageUrl
-            status
-            borrowerId
+      id
+      username
+      userGames {
+        userId
+        gameId
+        status
+        borrowerId
+        game {
+          id
+          boardGameAtlasId
+          url
+          name
+          yearPublished
+          minPlayers
+          maxPlayers
+          minPlaytime
+          maxPlaytime
+          minAge
+          description
+          thumbUrl
+          imageUrl
         }
+      }
+      borrowedGames {
+        userId
+        gameId
+        status
+        borrowerId
+        game {
+          name
+          id
+          boardGameAtlasId
+          url
+          name
+          yearPublished
+          minPlayers
+          maxPlayers
+          minPlaytime
+          maxPlaytime
+          minAge
+          description
+          thumbUrl
+          imageUrl
+        }
+      }
     }
   }`
+
+  //Example query response for single user
+  // {
+  //   “data”: {
+  //     “user”: {
+  //       “id”: “10",
+  //       “username”: “tuan”,
+  //       “userGames”: [
+  //         {
+  //           “userId”: 10,
+  //           “gameId”: 10,
+  //           “status”: 0,
+  //           “borrowerId”: null,
+  //           “game”: {
+  //             “id”: “10",
+  //             “boardGameAtlasId”: “ed8889",
+  //             “url”: “http://hegmann-cummings.io/charity”,
+  //             “name”: “Metroid Prime 3: Corruption”,
+  //             “yearPublished”: 2023,
+  //             “minPlayers”: 2,
+  //             “maxPlayers”: 7,
+  //             “minPlaytime”: 43,
+  //             “maxPlaytime”: 52,
+  //             “minAge”: 5,
+  //             “description”: “Suscipit laboriosam ratione. Voluptatum quasi tenetur. Consectetur amet atque.“,
+  //             “thumbUrl”: “http://fritsch.name/leola.morar”,
+  //             “imageUrl”: “https://loremflickr.com/300/300”
+  //           }
+  //         }
+  //       ],
+  //       “borrowedGames”: []
+  //     }
+  //   }
+  // }
 
 export const GET_GAME_DETAIL = (id) => gql`
     query {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -116,13 +116,15 @@ export const App = () => {
   //     console.log(data)
   //   }
   // })
-  const [GET_USER, { data, loading, error }] = useMutation(GET_USER("argdfga"));
+  // const [GET_USER, { data, loading, error }] = useMutation(GET_USER("argdfga"));
 
   useEffect(() => {
     if (error) {
+      console.log('ERROR: ', error.message);
       dispatch({ type: 'error', payload: error })
     }
     if (data) {
+      console.log('success');
       dispatch({ type: 'success', payload: data.user })
     }
   }, [data, loading, error])
@@ -150,7 +152,7 @@ export const App = () => {
 
   const setModal = (id = null) => {
     if (id) {
-      const modalInfo = state.user.games.find(game => game.id === id)
+      const modalInfo = state.user.userGames.find(game => +game.game.id === id)
       dispatch({ type: 'set_modal', payload: modalInfo })
     } else {
       dispatch({ type: 'set_modal' })

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -153,6 +153,7 @@ export const App = () => {
   const setModal = (id = null) => {
     if (id) {
       const modalInfo = state.user.userGames.find(game => +game.game.id === id)
+      //NOTE: modal does not work for borrowed games right now because borrowed games are coming from mock data, should be in same array once BE is set up.
       dispatch({ type: 'set_modal', payload: modalInfo })
     } else {
       dispatch({ type: 'set_modal' })

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -186,7 +186,7 @@ export const App = () => {
                 userName={state.userName}
               />
             } />
-          <Route path='/search-results/:searchTerm' element={<SearchResults results={state.searchResults} userInfo={state.user} searchBarSubmit={searchBarSubmit} setModal={setModal}/>  
+          <Route path='/search-results/:searchTerm' element={<SearchResults results={state.searchResults} userInfo={state.user} searchBarSubmit={searchBarSubmit} setModal={setModal}/> } />
           <Route path='/friends-games/:id' element={<FriendsGames userInfo={state.user} searchBarSubmit={searchBarSubmit} />} />
         </Routes>
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -186,7 +186,7 @@ export const App = () => {
                 userName={state.userName}
               />
             } />
-          <Route path='/search-results/:searchTerm' element={<SearchResults results={state.searchResults} userInfo={state.user} searchBarSubmit={searchBarSubmit}/> setModal={setModal} />
+          <Route path='/search-results/:searchTerm' element={<SearchResults results={state.searchResults} userInfo={state.user} searchBarSubmit={searchBarSubmit} setModal={setModal}/>  
           <Route path='/friends-games/:id' element={<FriendsGames userInfo={state.user} searchBarSubmit={searchBarSubmit} />} />
         </Routes>
       </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -13,9 +13,9 @@ import { useQuery } from "@apollo/client"
 // dummyJson will be deleted when we connect to API 
 const dummyJson = [
   {
-    "type": "game",
-    "id": 1,
-    "attributes": {
+    "_typename": "UserGame",
+    "game": {
+      "id": 1,
       "board_game_atlas_id": "VO7TAxQ5Qn",
       "name": "Dominion",
       "min_players": 2,
@@ -26,14 +26,14 @@ const dummyJson = [
       "year_published": 2008,
       "description": "<p>You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! <br /><br />In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.</p>\r\n<p>In <em><strong>Dominion</strong></em>, each player starts with an identical, very small deck of cards. In the center of the table is a selection of other cards the players can &quot;buy&quot; as they can afford them. Through their selection of cards to buy, and how they play their hands as they draw them, the players construct their deck on the fly, striving for the most efficient path to the precious victory points by game end.</p>",
       "thumb_url": "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1559254200326-6135RVKbZZL.jpg",
-      "image_url": "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1559254200326-6135RVKbZZL.jpg",
+      "imageUrl": "https://s3-us-west-1.amazonaws.com/5cc.images/games/uploaded/1559254200326-6135RVKbZZL.jpg",
       "url": "https://www.boardgameatlas.com/game/VO7TAxQ5Qn/dominion"
     }
   },
   {
-    "type": "game",
-    "id": 2,
-    "attributes": {
+    "_typename": "UserGame",
+    "game": {
+      "id": 2,
       "board_game_atlas_id": "oGVgRSAKwX",
       "name": "Carcassonne",
       "min_players": 2,
@@ -44,14 +44,14 @@ const dummyJson = [
       "year_published": 2000,
       "description": "<p>Each game of <em>Carcassonne</em> reveals a unique environment as tiles form a landscape of cities, roads, fields, and monasteries. Claim these features with your followers to win the game.</p>\r\n<p><em>Carcassonne</em> is a tile placement game where players collectively construct the area around the medieval French city of Carcassonne while competing to place followers on various features and score the most points.</p>\r\n<p>First published in 2000, the game's accessible yet deep design has attracted a wide fan base and led to the development of numerous expansions (eg Rivers) and standalone titles in the <em>Carcassonne</em> line.</p>",
       "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/carcassonne-board-game.jpg?v=1609629064",
-      "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/carcassonne-board-game.jpg?v=1609629064",
+      "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/carcassonne-board-game.jpg?v=1609629064",
       "url": "https://www.zmangames.com/en/products/carcassonne/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
     }
   },
   {
-    "type": "game",
-    "id": 3,
-    "attributes": {
+    "_typename": "UserGame",
+    "game": {
+      "id": 3,
       "board_game_atlas_id": "yqR4PtpO8X",
       "name": "Scythe",
       "min_players": 1,
@@ -62,7 +62,7 @@ const dummyJson = [
       "year_published": 2016,
       "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
       "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-      "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
+      "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
       "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
     }
   }
@@ -131,7 +131,7 @@ export const App = () => {
   const searchBarSubmit = (terms) => {
     let returnArray = []
     dummyJson.forEach(element => {
-      let name = element.attributes.name.toLowerCase()
+      let name = element.game.name.toLowerCase()
       if (name.includes(terms.toLowerCase())) {
         returnArray.push(element)
       }
@@ -164,6 +164,8 @@ export const App = () => {
     dispatch({ type: 'delete_game', payload: filteredGames })
   }
 
+console.log('state.serchreaults: ', state.searchResults);
+
   return (
     <div className='App'>
       <Routes>
@@ -182,7 +184,16 @@ export const App = () => {
               userName={state.userName}
             />
           } />
-        <Route path='/search-results/:searchTerm' element={<SearchResults results={state.searchResults} userInfo={state.user} searchBarSubmit={searchBarSubmit} />} />
+        <Route path='/search-results/:searchTerm' 
+          element={
+            <SearchResults 
+              results={state.searchResults} 
+              userInfo={state.user} 
+              searchBarSubmit={searchBarSubmit}
+              setModal={setModal} 
+            />
+          } 
+        />
         <Route path='/friends-games/:id' element={<FriendsGames />} />
       </Routes>
     </div>

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,10 +5,9 @@ import { UserDashboard } from '../User_Dashboard/User_Dashboard'
 import { Login } from '../Login/Login'
 import SearchResults from '../Search_Results/Search_Results'
 import { FriendsGames } from '../Friends_Games/Friends_Games'
-import dummyData from '../../dummy_user_data.json'
+// import dummyData from '../../dummy_user_data.json'
 import { GET_USER } from '../../GraphQL/queries'
-import { CREATE_USER } from '../../GraphQL/mutations'
-import { useQuery, useMutation } from "@apollo/client"
+import { useQuery } from "@apollo/client"
 
 
 // dummyJson will be deleted when we connect to API 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,7 +7,8 @@ import SearchResults from '../Search_Results/Search_Results'
 import { FriendsGames } from '../Friends_Games/Friends_Games'
 import dummyData from '../../dummy_user_data.json'
 import { GET_USER } from '../../GraphQL/queries'
-import { useQuery } from "@apollo/client"
+import { CREATE_USER } from '../../GraphQL/mutations'
+import { useQuery, useMutation } from "@apollo/client"
 
 
 // dummyJson will be deleted when we connect to API 
@@ -110,6 +111,12 @@ export const App = () => {
 
   const [state, dispatch] = useReducer(reducer, initialState)
   const { loading, error, data } = useQuery(GET_USER(state.userName))
+  // const [mutation] = useMutation(CREATE_USER('CoolGuy1975'), {
+  //   onCompleted: (data) => {
+  //     console.log(data)
+  //   }
+  // })
+  const [GET_USER, { data, loading, error }] = useMutation(GET_USER("argdfga"));
 
   useEffect(() => {
     if (error) {
@@ -155,8 +162,6 @@ export const App = () => {
     dispatch({ type: 'delete_game', payload: filteredGames })
   }
 
-  console.log(state.user)
-  console.log(error)
   return (
     <div className='App'>
       <Routes>

--- a/src/components/Game_Modal/Game_Modal.js
+++ b/src/components/Game_Modal/Game_Modal.js
@@ -20,7 +20,7 @@ export const GameModal = ({ setModal, deleteGame, context, modal }) => {
           <button className='close-modal-button' onClick={() => setModal()}>X</button>
         </span>
         <span className='modal-header'>
-          <h1>{modal.name}</h1><p>({modal.game.yearPublished})</p>
+          <h1>{modal.game.name}</h1><p>({modal.game.yearPublished})</p>
         </span>
         <div className='modal-content'>
           <img className='modal-image' alt={`Box Cover of ${modal.game.name}`} src={modal.game.imageUrl} />

--- a/src/components/Game_Modal/Game_Modal.js
+++ b/src/components/Game_Modal/Game_Modal.js
@@ -3,12 +3,12 @@ import './Game_Modal.css'
 
 export const GameModal = ({ setModal, deleteGame, context, modal }) => {
 
-  let averagePlayTime = (modal.minPlaytime + modal.maxPlaytime) / 2
+  let averagePlayTime = (modal.game.minPlaytime + modal.game.maxPlaytime) / 2
 
   //Lines 6 through 11 are only for cleaning up the dummy data that (specifically the game description)
   //I think matches what we will get from the server. If not, this code can be deleted.
   let array = ['<p>', '</p>', '<em>', '</em>', '<br>', '<br />', '<strong>', '</strong>']
-  let string = modal.description
+  let string = modal.game.description
   array.forEach(val => {
     string = string.replaceAll(val, '')
   })
@@ -20,20 +20,20 @@ export const GameModal = ({ setModal, deleteGame, context, modal }) => {
           <button className='close-modal-button' onClick={() => setModal()}>X</button>
         </span>
         <span className='modal-header'>
-          <h1>{modal.name}</h1><p>({modal.yearPublished})</p>
+          <h1>{modal.name}</h1><p>({modal.game.yearPublished})</p>
         </span>
         <div className='modal-content'>
-          <img className='modal-image' alt={`Box Cover of ${modal.name}`} src={modal.imageUrl} />
+          <img className='modal-image' alt={`Box Cover of ${modal.game.name}`} src={modal.game.imageUrl} />
           <div className='modal-details'>
-            <p>Players: {modal.minPlayers} to {modal.maxPlayers}</p>
+            <p>Players: {modal.game.minPlayers} to {modal.game.maxPlayers}</p>
             <p>Average Playtime: {averagePlayTime} minutes</p>
-            <p>Age: {modal.minAge}+</p>
+            <p>Age: {modal.game.minAge}+</p>
             <p>{string}</p>
-            <a href={modal.url} target='_blank' rel="noreferrer">More Info</a>
+            <a href={modal.game.url} target='_blank' rel="noreferrer">More Info</a>
           </div>
         </div>
         <div className='modal-buttons'>
-          {context === 'user_dashboard' && <button className='modal-button delete-button' onClick={() => deleteGame(modal.id)}>Delete</button>}
+          {context === 'user_dashboard' && <button className='modal-button delete-button' onClick={() => deleteGame(+modal.game.id)}>Delete</button>}
           {context === 'user_dashboard' && <button className='modal-button'>Make Private</button>}
           {context === 'search' && <button className='modal-button'>Add to Collection</button>}
           {context === 'friends_games' && <button className='modal-button'>Borrow</button>}

--- a/src/components/Game_Modal/Game_Modal.js
+++ b/src/components/Game_Modal/Game_Modal.js
@@ -3,12 +3,12 @@ import './Game_Modal.css'
 
 export const GameModal = ({ setModal, deleteGame, context, modal }) => {
 
-  let averagePlayTime = (modal.attributes.min_playtime + modal.attributes.max_playtime) / 2
+  let averagePlayTime = (modal.minPlaytime + modal.maxPlaytime) / 2
 
   //Lines 6 through 11 are only for cleaning up the dummy data that (specifically the game description)
   //I think matches what we will get from the server. If not, this code can be deleted.
   let array = ['<p>', '</p>', '<em>', '</em>', '<br>', '<br />', '<strong>', '</strong>']
-  let string = modal.attributes.description
+  let string = modal.description
   array.forEach(val => {
     string = string.replaceAll(val, '')
   })
@@ -20,16 +20,16 @@ export const GameModal = ({ setModal, deleteGame, context, modal }) => {
           <button className='close-modal-button' onClick={() => setModal()}>X</button>
         </span>
         <span className='modal-header'>
-          <h1>{modal.attributes.name}</h1><p>({modal.attributes.year_published})</p>
+          <h1>{modal.name}</h1><p>({modal.yearPublished})</p>
         </span>
         <div className='modal-content'>
-          <img className='modal-image' alt={`Box Cover of ${modal.attributes.name}`} src={modal.attributes.image_url} />
+          <img className='modal-image' alt={`Box Cover of ${modal.name}`} src={modal.imageUrl} />
           <div className='modal-details'>
-            <p>Players: {modal.attributes.min_players} to {modal.attributes.max_players}</p>
+            <p>Players: {modal.minPlayers} to {modal.maxPlayers}</p>
             <p>Average Playtime: {averagePlayTime} minutes</p>
-            <p>Age: {modal.attributes.min_age}+</p>
+            <p>Age: {modal.minAge}+</p>
             <p>{string}</p>
-            <a href={modal.attributes.url} target='_blank' rel="noreferrer">More Info</a>
+            <a href={modal.url} target='_blank' rel="noreferrer">More Info</a>
           </div>
         </div>
         <div className='modal-buttons'>

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -11,7 +11,7 @@ export const Login = ({setUserName}) => {
 
   useEffect(() => {
     // Hard coding usernames; as an extension, could do a query on page load.
-    setExistingUserNames(["randy", "Pickafloof", "GarBear88"])
+    setExistingUserNames(["Pickafloof", "randy", "mikedao", "abdulredd", "heatherf", "jeff", "drake", "dug", "honey", "jakeandbake"])
   }, []);
 
   useEffect(() => {

--- a/src/components/Search_Results/Search_Results.js
+++ b/src/components/Search_Results/Search_Results.js
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom'
 import { Navbar } from '../Navbar/Navbar'
 import SingleGame from '../Single_Game/Single_Game'
 
-const SearchResults = ({ results, searchBarSubmit, userInfo }) => {
-  const games = results.map(game => <SingleGame game={game} key={game.id} />)
+const SearchResults = ({ results, searchBarSubmit, userInfo, setModal }) => {
+  console.log(results);
+  const games = results.map(game => <SingleGame game={game} key={game.id} setModal={setModal}/>)
 
   return (
     <div>

--- a/src/components/Single_Game/Single_Game.js
+++ b/src/components/Single_Game/Single_Game.js
@@ -10,8 +10,8 @@ import './Single_Game.css'
 const SingleGame = ({ game, setModal }) => {
   return (
     <div className="single-tile" id={game.id} onClick={() => setModal(game.id)}>
-      <h2 className="single-game-name">{game.attributes.name}</h2>
-      <img className="single-game-img" src={game.attributes.image_url} alt={game.attributes.name} />
+      <h2 className="single-game-name">{game.name}</h2>
+      <img className="single-game-img" src={game.imageUrl} alt={game.name} />
     </div>
   )
 }

--- a/src/components/Single_Game/Single_Game.js
+++ b/src/components/Single_Game/Single_Game.js
@@ -1,17 +1,12 @@
 import React from "react"
 import './Single_Game.css'
 
-/*
-  Game object being passed in will need a boolean of whether borrowed is true or not;
-  If it is borrowed AND it is in User's games, it will conditionally render as greyed out;
-  If it is NOT borrowed, it will render as below
-*/
 
 const SingleGame = ({ game, setModal }) => {
   return (
-    <div className="single-tile" id={game.id} onClick={() => setModal(game.id)}>
-      <h2 className="single-game-name">{game.name}</h2>
-      <img className="single-game-img" src={game.imageUrl} alt={game.name} />
+    <div className="single-tile" id={+game.game.id} onClick={() => setModal(+game.game.id)}>
+      <h2 className="single-game-name">{game.game.name}</h2>
+      <img className="single-game-img" src={game.game.imageUrl} alt={game.game.name} />
     </div>
   )
 }

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -6,23 +6,28 @@ import './User_Dashboard.css'
 import fakeBorrowedGames from '../../dummy-borrowed-games.json'
 import { GET_ALL_USERS } from '../../GraphQL/queries'
 import { useQuery } from '@apollo/client'
+import { Link } from 'react-router-dom'
 
 
 export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal, modal, loading, error, data, userName }) => {
-console.log('modal: ', modal);
-console.log('userInfo: ', userInfo);
-  useEffect(() => {
 
-  }, [])
+  const allUsersLoading = useQuery(GET_ALL_USERS).loading;
+  const allUsersError = useQuery(GET_ALL_USERS).error;
+  const allUsersData = useQuery(GET_ALL_USERS).data;
+  const friendsList = allUsersData ? allUsersData.users.filter(user => user.username !== userInfo.username) : [];
+  const friends = friendsList.map(friend => {
+    return (<Link to={`/friends-games/${friend.id}`}> 
+              <p key={friend.id} className="friend">{friend.username}</p>
+            </Link>)
+    })
 
  /* if (loading) {
     return <h1>LOADING...</h1>
   } */
-  // remove this 'if' (duplicate)...
+  // NOTE: remove 👆, duplicate of conditional rendering below
 
 
-  let borrowedGamesThumbnails = fakeBorrowedGames.userGames.map((game, index) => <SingleGame key={index} game={game} setModal={setModal}/>)
-  //const friends = userInfo.friends.map(friend => <p key={friend} className="friend">{friend}</p>)
+  let borrowedGamesThumbnails = fakeBorrowedGames.userGames.map((game, index) => <SingleGame key={index+20} game={game} setModal={setModal}/>)
   const games = userInfo.userGames.map(game => <SingleGame key={game.game.id} game={game} setModal={setModal} />)
 
   return (
@@ -42,8 +47,10 @@ console.log('userInfo: ', userInfo);
           </div>
           <div className='friends-section'>
             <h1 className='my-friends-header'>My Friends</h1>
-            {/* <div className='friends-list'>{friends}</div> */}
-            <div className='friends-list'>FRIENDS!</div>
+            {allUsersLoading && <h2>Loading friends...</h2>}
+            {allUsersError && <h2>Trouble loading friends!</h2>}
+            {allUsersData && <div className='friends-list'></div>}
+            <div className='friends-list'>{friends}</div>
           </div>
         </>}
       </div>

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -8,8 +8,11 @@ import fakeBorrowedGames from '../../dummy-borrowed-games.json'
 
 export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal, modal, loading, error, data, userName }) => {
 
+  if (loading) {
+    return <h1>LOADING...</h1>
+  }
   let borrowedGamesThumbnails = fakeBorrowedGames.games.map((game, index) => <SingleGame key={index} game={game} setModal={setModal}/>)
-  const friends = userInfo.friends.map(friend => <p key={friend} className="friend">{friend}</p>)
+  //const friends = userInfo.friends.map(friend => <p key={friend} className="friend">{friend}</p>)
   const games = userInfo.games.map(game => <SingleGame key={game.id} game={game} setModal={setModal} />)
 
   return (
@@ -29,7 +32,8 @@ export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal,
           </div>
           <div className='friends-section'>
             <h1 className='my-friends-header'>My Friends</h1>
-            <div className='friends-list'>{friends}</div>
+            {/* <div className='friends-list'>{friends}</div> */}
+            <div className='friends-list'>FRIENDS!</div>
           </div>
         </>}
       </div>

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -1,19 +1,29 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Navbar } from '../Navbar/Navbar'
 import { GameModal } from '../Game_Modal/Game_Modal'
 import SingleGame from '../Single_Game/Single_Game'
 import './User_Dashboard.css'
 import fakeBorrowedGames from '../../dummy-borrowed-games.json'
+import { GET_ALL_USERS } from '../../GraphQL/queries'
+import { useQuery } from '@apollo/client'
 
 
 export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal, modal, loading, error, data, userName }) => {
+console.log('modal: ', modal);
+console.log('userInfo: ', userInfo);
+  useEffect(() => {
 
-  if (loading) {
+  }, [])
+
+ /* if (loading) {
     return <h1>LOADING...</h1>
-  }
-  let borrowedGamesThumbnails = fakeBorrowedGames.games.map((game, index) => <SingleGame key={index} game={game} setModal={setModal}/>)
+  } */
+  // remove this 'if' (duplicate)...
+
+
+  let borrowedGamesThumbnails = fakeBorrowedGames.userGames.map((game, index) => <SingleGame key={index} game={game} setModal={setModal}/>)
   //const friends = userInfo.friends.map(friend => <p key={friend} className="friend">{friend}</p>)
-  const games = userInfo.games.map(game => <SingleGame key={game.id} game={game} setModal={setModal} />)
+  const games = userInfo.userGames.map(game => <SingleGame key={game.game.id} game={game} setModal={setModal} />)
 
   return (
     <>

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -26,9 +26,9 @@ export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal,
   } */
   // NOTE: remove 👆, duplicate of conditional rendering below
 
-
+console.log('userInfo: ', userInfo);
   let borrowedGamesThumbnails = fakeBorrowedGames.userGames.map((game, index) => <SingleGame key={index+20} game={game} setModal={setModal}/>)
-  const games = userInfo.userGames.map(game => <SingleGame key={game.game.id} game={game} setModal={setModal} />)
+  const games = userInfo ? userInfo.userGames.map(game => <SingleGame key={game.game.id} game={game} setModal={setModal} />) : []
 
   return (
     <>

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Navbar } from '../Navbar/Navbar'
 import { GameModal } from '../Game_Modal/Game_Modal'
 import SingleGame from '../Single_Game/Single_Game'

--- a/src/components/User_Dashboard/User_Dashboard.js
+++ b/src/components/User_Dashboard/User_Dashboard.js
@@ -16,7 +16,7 @@ export const UserDashboard = ({ userInfo, searchBarSubmit, deleteGame, setModal,
   const allUsersData = useQuery(GET_ALL_USERS).data;
   const friendsList = allUsersData ? allUsersData.users.filter(user => user.username !== userInfo.username) : [];
   const friends = friendsList.map(friend => {
-    return (<Link to={`/friends-games/${friend.id}`}> 
+    return (<Link to={`/friends-games/${friend.id}`} key={friend.id}> 
               <p key={friend.id} className="friend">{friend.username}</p>
             </Link>)
     })

--- a/src/dummy-borrowed-games.json
+++ b/src/dummy-borrowed-games.json
@@ -1,165 +1,17 @@
 {
-  "games": [
+  "userGames": [
     {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
+      "game": {
+        "id": 3,
+        "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
+        "name": "Scythe"
       }
     },
     {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 2,
-      "attributes": {
-        "board_game_atlas_id": "oGVgRSAKwX",
-        "name": "Carcassonne",
-        "min_players": 2,
-        "max_players": 5,
-        "min_playtime": 30,
-        "max_playtime": 45,
-        "min_age": 7,
-        "year_published": 2000,
-        "description": "<p>Each game of <em>Carcassonne</em> reveals a unique environment as tiles form a landscape of cities, roads, fields, and monasteries. Claim these features with your followers to win the game.</p>\r\n<p><em>Carcassonne</em> is a tile placement game where players collectively construct the area around the medieval French city of Carcassonne while competing to place followers on various features and score the most points.</p>\r\n<p>First published in 2000, the game's accessible yet deep design has attracted a wide fan base and led to the development of numerous expansions (eg Rivers) and standalone titles in the <em>Carcassonne</em> line.</p>",
-        "thumb_url": "https://cdn11.bigcommerce.com/s-wue8xznink/images/stencil/1280x1280/products/357/17642/pic6544250_1__09565.1658423124.png?c=2",
-        "image_url": "https://cdn11.bigcommerce.com/s-wue8xznink/images/stencil/1280x1280/products/357/17642/pic6544250_1__09565.1658423124.png?c=2",
-        "url": "https://www.zmangames.com/en/products/carcassonne/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 2,
-      "attributes": {
-        "board_game_atlas_id": "oGVgRSAKwX",
-        "name": "Carcassonne",
-        "min_players": 2,
-        "max_players": 5,
-        "min_playtime": 30,
-        "max_playtime": 45,
-        "min_age": 7,
-        "year_published": 2000,
-        "description": "<p>Each game of <em>Carcassonne</em> reveals a unique environment as tiles form a landscape of cities, roads, fields, and monasteries. Claim these features with your followers to win the game.</p>\r\n<p><em>Carcassonne</em> is a tile placement game where players collectively construct the area around the medieval French city of Carcassonne while competing to place followers on various features and score the most points.</p>\r\n<p>First published in 2000, the game's accessible yet deep design has attracted a wide fan base and led to the development of numerous expansions (eg Rivers) and standalone titles in the <em>Carcassonne</em> line.</p>",
-        "thumb_url": "https://cdn11.bigcommerce.com/s-wue8xznink/images/stencil/1280x1280/products/357/17642/pic6544250_1__09565.1658423124.png?c=2",
-        "image_url": "https://cdn11.bigcommerce.com/s-wue8xznink/images/stencil/1280x1280/products/357/17642/pic6544250_1__09565.1658423124.png?c=2",
-        "url": "https://www.zmangames.com/en/products/carcassonne/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
-      }
-    },
-    {
-      "type": "game",
-      "id": 3,
-      "attributes": {
-        "board_game_atlas_id": "yqR4PtpO8X",
-        "name": "Scythe",
-        "min_players": 1,
-        "max_players": 5,
-        "min_playtime": 90,
-        "max_playtime": 120,
-        "min_age": 14,
-        "year_published": 2016,
-        "description": "<p><em>Scythe</em> gives players almost complete control over their fate. Other than each player's individual hidden objective card, the only elements of luck or variability are &quot;Encounter&quot; cards that players will draw as they interact with the citizens of newly explored lands. Each encounter card provides the player with several options, allowing them to mitigate the luck of the draw through their selection. Combat is also driven by choices, not luck or randomness.<br /><br /><em>Scythe</em> uses a streamlined action-selection mechanism (no rounds or phases) to keep gameplay moving at a brisk pace and reduce downtime between turns. While there is plenty of direct conflict for players who seek it, there is no player elimination.<br /><br />Every part of <em>Scythe</em> has an aspect of engine-building to it. Players can upgrade actions to become more efficient, build structures that improve their position on the map, enlist new recruits to enhance character abilities, activate mechs to deter opponents from invading, and expand their borders to reap greater types and quantities of resources. These engine-building aspects create a sense of momentum and progress throughout the game. The order in which players improve their engine adds to the unique feel of each game, even when playing one faction multiple times.</p>",
-        "thumb_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "image_url": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
-        "url": "https://stonemaiergames.com/games/scythe/?utm_source=boardgameatlas.com&utm_medium=search&utm_campaign=bga_ads"
+      "game": {
+        "id": 3,
+        "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
+        "name": "Scythe"
       }
     }
   ]

--- a/src/dummy-borrowed-games.json
+++ b/src/dummy-borrowed-games.json
@@ -2,14 +2,14 @@
   "userGames": [
     {
       "game": {
-        "id": 3,
+        "id": "3",
         "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
         "name": "Scythe"
       }
     },
     {
       "game": {
-        "id": 3,
+        "id": "3",
         "imageUrl": "https://cdn.shopify.com/s/files/1/0513/4077/1515/products/scythe-board-game.jpg?v=1611090922",
         "name": "Scythe"
       }


### PR DESCRIPTION
#### What's this PR do?

- Adds functionality so that when user dashboard loads, the friends list automatically populates from a query to back end.
- Also, refactors several components that rely on game data so that it reflects the new syntax received from back end. This necessitated updating the test files too
- Login page now has capabilities for all users to log in

#### Where should the reviewer start?
UserDashboard
#### How should this be manually tested?
Login, view and click on the names

#### Any background context you want to provide?
We'll need to be cognizant going forward of the game data we're getting back from BE if it changes as it will require a lot of changes on our end